### PR TITLE
src, tests: add full Marvin API support with task editing, habits, events, reminders, and rewards

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,4 +80,4 @@ name = "amazing-marvin-mcp"
 display_name = "Amazing Marvin MCP"
 description = "Model Context Provider for Amazing Marvin productivity app"
 entry_point = "amazing_marvin_mcp.main:start"
-environment_variables = ["AMAZING_MARVIN_API_KEY"]
+environment_variables = ["AMAZING_MARVIN_API_KEY", "AMAZING_MARVIN_FULL_ACCESS_TOKEN"]

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -11,6 +11,7 @@ local:
   args: ["-m", "amazing_marvin_mcp"]
   environment_variables:
     - AMAZING_MARVIN_API_KEY
+    - AMAZING_MARVIN_FULL_ACCESS_TOKEN
     - MCP_TRANSPORT=http
     - MCP_HOST=localhost
     - MCP_PORT=8000
@@ -22,6 +23,7 @@ remote:
   entry_point: "amazing_marvin_mcp.main:start"
   environment_variables:
     - AMAZING_MARVIN_API_KEY
+    - AMAZING_MARVIN_FULL_ACCESS_TOKEN
     - MCP_TRANSPORT=http
     - MCP_HOST=0.0.0.0
     - MCP_PORT=8000

--- a/src/amazing_marvin_mcp/api.py
+++ b/src/amazing_marvin_mcp/api.py
@@ -11,39 +11,63 @@ logger = logging.getLogger(__name__)
 def create_api_client() -> "MarvinAPIClient":
     """Create API client with settings."""
     settings = get_settings()
-    return MarvinAPIClient(api_key=settings.amazing_marvin_api_key)
+    return MarvinAPIClient(
+        api_key=settings.amazing_marvin_api_key,
+        full_access_token=settings.amazing_marvin_full_access_token,
+    )
 
 
 class MarvinAPIClient:
     """API client for Amazing Marvin"""
 
-    def __init__(self, api_key: str):
+    def __init__(self, api_key: str, full_access_token: str | None = None):
         """
         Initialize the API client with the API key
 
         Args:
             api_key: Amazing Marvin API key
+            full_access_token: Optional full access token for doc read/update operations
         """
         self.api_key = api_key
+        self.full_access_token = full_access_token
         self.base_url = "https://serv.amazingmarvin.com/api"  # Removed v1 from URL
         self.headers = {"X-API-Token": api_key}
+        self.full_access_headers: dict[str, str] | None = (
+            {"X-Full-Access-Token": full_access_token} if full_access_token else None
+        )
+
+    def _get_headers(self, use_full_access: bool = False) -> dict[str, str]:
+        """Get the appropriate headers for the request."""
+        if use_full_access:
+            if not self.full_access_headers:
+                raise ValueError(
+                    "Full access token is required for this operation. "
+                    "Set AMAZING_MARVIN_FULL_ACCESS_TOKEN environment variable."
+                )
+            return self.full_access_headers
+        return self.headers
 
     def _make_request(
-        self, method: str, endpoint: str, data: dict | None = None
+        self,
+        method: str,
+        endpoint: str,
+        data: dict | None = None,
+        use_full_access: bool = False,
     ) -> Any:
         """Make a request to the API"""
         url = f"{self.base_url}{endpoint}"
+        headers = self._get_headers(use_full_access)
         logger.debug("Making %s request to %s", method, url)
 
         try:
             if method.lower() == "get":
-                response = requests.get(url, headers=self.headers)
+                response = requests.get(url, headers=headers)
             elif method.lower() == "post":
-                response = requests.post(url, headers=self.headers, json=data)
+                response = requests.post(url, headers=headers, json=data)
             elif method.lower() == "put":
-                response = requests.put(url, headers=self.headers, json=data)
+                response = requests.put(url, headers=headers, json=data)
             elif method.lower() == "delete":
-                response = requests.delete(url, headers=self.headers)
+                response = requests.delete(url, headers=headers)
             else:
                 raise ValueError(f"Unsupported HTTP method: {method}")
 
@@ -71,11 +95,8 @@ class MarvinAPIClient:
         return self._make_request("get", endpoint)
 
     def get_task(self, task_id: str) -> dict:
-        """Get a specific task or project by ID (requires full access token, not supported by default API token)"""
-        # The Marvin API does not provide a direct /tasks/{id} endpoint. Use /api/doc?id=... with full access token for arbitrary docs.
-        raise NotImplementedError(
-            "Direct task lookup by ID is not supported with the standard API token. Use /api/doc?id=... with full access token."
-        )
+        """Get a specific task or project by ID (requires full access token)."""
+        return self.get_document(task_id)
 
     def get_projects(self) -> list[dict]:
         """
@@ -221,14 +242,68 @@ class MarvinAPIClient:
         """Create a new project (experimental endpoint)"""
         return self._make_request("post", "/addProject", data=project_data)
 
-    def update_task(self, task_id: str, task_data: dict) -> dict:
-        """Update a task (requires full access token and /api/doc/update)"""
-        raise NotImplementedError(
-            "Task update is not supported with the standard API token. Use /api/doc/update with full access token."
+    def update_task(self, item_id: str, setters: dict) -> dict:
+        """Update a task using setters format (requires full access token)."""
+        return self.update_document(item_id, setters)
+
+    # --- Full Access Token Methods ---
+
+    def get_document(self, doc_id: str) -> dict:
+        """Read any document by ID (requires full access token)."""
+        return self._make_request("get", f"/doc?id={doc_id}", use_full_access=True)
+
+    def update_document(self, item_id: str, setters: dict) -> dict:
+        """Update a document using setters format (requires full access token)."""
+        data = {"itemId": item_id, **setters}
+        return self._make_request("post", "/doc/update", data=data, use_full_access=True)
+
+    # --- Standard Token Methods ---
+
+    def add_event(self, event_data: dict) -> dict:
+        """Create a calendar event."""
+        return self._make_request("post", "/addEvent", data=event_data)
+
+    def get_today_time_blocks(self, date: str | None = None) -> list[dict]:
+        """Get time blocks for a date (defaults to today)."""
+        endpoint = "/todayTimeBlocks"
+        if date:
+            endpoint += f"?date={date}"
+        return self._make_request("get", endpoint)
+
+    def get_habits(self) -> list[dict]:
+        """Get all habits."""
+        return self._make_request("get", "/habits")
+
+    def get_habit(self, habit_id: str) -> dict:
+        """Get a single habit by ID."""
+        return self._make_request("get", f"/habit?id={habit_id}")
+
+    def update_habit(self, habit_data: dict) -> dict:
+        """Record or undo a habit occurrence."""
+        return self._make_request("post", "/updateHabit", data=habit_data)
+
+    def set_reminders(self, reminders: list[dict]) -> dict:
+        """Set reminders."""
+        return self._make_request("post", "/reminder/set", data={"reminders": reminders})
+
+    def delete_reminders(self, reminder_ids: list[str]) -> dict:
+        """Delete specific reminders by ID."""
+        return self._make_request(
+            "post", "/reminder/delete", data={"reminderIds": reminder_ids}
         )
 
-    def delete_task(self, task_id: str) -> dict:
-        """Delete a task (requires full access token and /api/doc/delete)"""
-        raise NotImplementedError(
-            "Task deletion is not supported with the standard API token. Use /api/doc/delete with full access token."
+    def unclaim_reward_points(self, item_id: str, date: str) -> dict:
+        """Unclaim reward points for an item."""
+        return self._make_request(
+            "post",
+            "/unclaimRewardPoints",
+            data={"itemId": item_id, "date": date},
+        )
+
+    def spend_reward_points(self, points: int, date: str) -> dict:
+        """Spend reward points."""
+        return self._make_request(
+            "post",
+            "/spendRewardPoints",
+            data={"points": points, "date": date},
         )

--- a/src/amazing_marvin_mcp/config.py
+++ b/src/amazing_marvin_mcp/config.py
@@ -15,6 +15,9 @@ class Settings(BaseSettings):
 
     # API settings
     amazing_marvin_api_key: str = Field(..., env="AMAZING_MARVIN_API_KEY")
+    amazing_marvin_full_access_token: str | None = Field(
+        default=None, env="AMAZING_MARVIN_FULL_ACCESS_TOKEN"
+    )
 
     # Server settings
     port: int = Field(default=3000, env="PORT")

--- a/src/amazing_marvin_mcp/documents.py
+++ b/src/amazing_marvin_mcp/documents.py
@@ -1,0 +1,27 @@
+"""Document read/update operations via /doc/* endpoints."""
+
+from typing import Any
+
+from .api import MarvinAPIClient
+from .models import TaskUpdateRequest
+from .setters_builder import build_setters
+
+
+def get_document(api_client: MarvinAPIClient, doc_id: str) -> dict[str, Any]:
+    """Read any document by ID."""
+    return api_client.get_document(doc_id)
+
+
+def update_task_friendly(
+    api_client: MarvinAPIClient, update: TaskUpdateRequest
+) -> dict[str, Any]:
+    """Update a task using the friendly TaskUpdateRequest model."""
+    setters = build_setters(update)
+    return api_client.update_document(update.item_id, setters)
+
+
+def update_document_raw(
+    api_client: MarvinAPIClient, item_id: str, setters: dict
+) -> dict[str, Any]:
+    """Update a document with raw setters for power users."""
+    return api_client.update_document(item_id, setters)

--- a/src/amazing_marvin_mcp/events.py
+++ b/src/amazing_marvin_mcp/events.py
@@ -1,0 +1,31 @@
+"""Event creation and time block operations."""
+
+from typing import Any
+
+from .api import MarvinAPIClient
+
+
+def add_event(
+    api_client: MarvinAPIClient,
+    title: str,
+    start: str,
+    length_minutes: int,
+    note: str | None = None,
+) -> dict[str, Any]:
+    """Create a calendar event. Converts length_minutes to milliseconds for Marvin."""
+    ms_per_minute = 60_000
+    event_data: dict[str, Any] = {
+        "title": title,
+        "start": start,
+        "length": length_minutes * ms_per_minute,
+    }
+    if note is not None:
+        event_data["note"] = note
+    return api_client.add_event(event_data)
+
+
+def get_today_time_blocks(
+    api_client: MarvinAPIClient, date: str | None = None
+) -> list[dict[str, Any]]:
+    """Get time blocks for a date (defaults to today)."""
+    return api_client.get_today_time_blocks(date)

--- a/src/amazing_marvin_mcp/habits.py
+++ b/src/amazing_marvin_mcp/habits.py
@@ -1,0 +1,30 @@
+"""Habit operations."""
+
+from typing import Any
+
+from .api import MarvinAPIClient
+
+
+def get_habits(api_client: MarvinAPIClient) -> list[dict[str, Any]]:
+    """List all habits."""
+    return api_client.get_habits()
+
+
+def get_habit(api_client: MarvinAPIClient, habit_id: str) -> dict[str, Any]:
+    """Get a single habit with history."""
+    return api_client.get_habit(habit_id)
+
+
+def record_habit(
+    api_client: MarvinAPIClient, habit_id: str, value: int | None = None
+) -> dict[str, Any]:
+    """Record a habit occurrence."""
+    data: dict[str, Any] = {"habitId": habit_id, "action": "record"}
+    if value is not None:
+        data["value"] = value
+    return api_client.update_habit(data)
+
+
+def undo_habit(api_client: MarvinAPIClient, habit_id: str) -> dict[str, Any]:
+    """Undo last habit recording."""
+    return api_client.update_habit({"habitId": habit_id, "action": "undo"})

--- a/src/amazing_marvin_mcp/main.py
+++ b/src/amazing_marvin_mcp/main.py
@@ -16,13 +16,53 @@ from .analytics import (
     get_productivity_summary_for_time_range as get_productivity_summary_for_time_range_impl,
 )
 from .api import create_api_client
+from .documents import (
+    get_document as get_document_impl,
+)
+from .documents import (
+    update_document_raw as update_document_raw_impl,
+)
+from .documents import (
+    update_task_friendly as update_task_friendly_impl,
+)
+from .events import (
+    add_event as add_event_impl,
+)
+from .events import (
+    get_today_time_blocks as get_today_time_blocks_impl,
+)
+from .habits import (
+    get_habit as get_habit_impl,
+)
+from .habits import (
+    get_habits as get_habits_impl,
+)
+from .habits import (
+    record_habit as record_habit_impl,
+)
+from .habits import (
+    undo_habit as undo_habit_impl,
+)
+from .models import TaskUpdateRequest
 from .projects import (
     create_project_with_tasks as create_project_impl,
 )
 from .projects import (
     get_project_overview as get_project_overview_impl,
 )
+from .reminders import (
+    delete_reminders as delete_reminders_impl,
+)
+from .reminders import (
+    set_reminders as set_reminders_impl,
+)
 from .response_models import StandardResponse
+from .rewards import (
+    spend_reward_points as spend_reward_points_impl,
+)
+from .rewards import (
+    unclaim_reward_points as unclaim_reward_points_impl,
+)
 from .tasks import (
     batch_create_tasks as batch_create_tasks_impl,
 )
@@ -881,6 +921,393 @@ async def get_completed_tasks_for_date(
     except Exception as e:
         logger.exception("Failed to get completed tasks for %s", date)
         return create_error_response(e, "/doneItems", debug, start_time)
+
+
+@mcp.tool()
+async def get_document(doc_id: str, debug: bool = False) -> StandardResponse:
+    """Read any Amazing Marvin document by ID (requires full access token).
+
+    Args:
+        doc_id: Document/task/project ID to read
+    """
+    start_time = time.time()
+    try:
+        api_client = create_api_client()
+        result = get_document_impl(api_client, doc_id)
+
+        return create_simple_response(
+            data=result,
+            summary_text=f"Retrieved document {doc_id}",
+            api_endpoint="/doc",
+            api_calls_made=1,
+            debug=debug,
+            start_time=start_time,
+        )
+    except Exception as e:
+        logger.exception("Failed to get document %s", doc_id)
+        return create_error_response(e, "/doc", debug, start_time)
+
+
+@mcp.tool()
+async def update_task(
+    item_id: str,
+    title: str | None = None,
+    due_date: str | None = None,
+    scheduled_date: str | None = None,
+    note: str | None = None,
+    label_ids: list[str] | None = None,
+    priority: str | None = None,
+    parent_id: str | None = None,
+    is_starred: bool | None = None,
+    is_frogged: bool | None = None,
+    time_estimate: int | None = None,
+    backburner: bool | None = None,
+    debug: bool = False,
+) -> StandardResponse:
+    """Update a task in Amazing Marvin (requires full access token).
+
+    Args:
+        item_id: Task ID to update
+        title: New title
+        due_date: Due date in YYYY-MM-DD format
+        scheduled_date: Scheduled date in YYYY-MM-DD format (maps to 'day' in Marvin)
+        note: Task notes/description
+        label_ids: List of label IDs to assign
+        priority: Priority level
+        parent_id: Parent project/task ID
+        is_starred: Star the task
+        is_frogged: Frog the task (eat-the-frog methodology)
+        time_estimate: Time estimate in minutes
+        backburner: Move to backburner
+    """
+    start_time = time.time()
+    try:
+        api_client = create_api_client()
+        update = TaskUpdateRequest(
+            item_id=item_id,
+            title=title,
+            due_date=due_date,
+            scheduled_date=scheduled_date,
+            note=note,
+            label_ids=label_ids,
+            priority=priority,
+            parent_id=parent_id,
+            is_starred=is_starred,
+            is_frogged=is_frogged,
+            time_estimate=time_estimate,
+            backburner=backburner,
+        )
+        result = update_task_friendly_impl(api_client, update)
+
+        return create_simple_response(
+            data=result,
+            summary_text=f"Updated task {item_id}",
+            api_endpoint="/doc/update",
+            api_calls_made=1,
+            debug=debug,
+            start_time=start_time,
+        )
+    except Exception as e:
+        logger.exception("Failed to update task %s", item_id)
+        return create_error_response(e, "/doc/update", debug, start_time)
+
+
+@mcp.tool()
+async def update_document_raw(
+    item_id: str, setters: dict, debug: bool = False
+) -> StandardResponse:
+    """Update any Amazing Marvin document with raw setters (power users, requires full access token).
+
+    Args:
+        item_id: Document ID to update
+        setters: Raw setters dict in Marvin format (e.g. {"$set": {"title": "New Title"}})
+    """
+    start_time = time.time()
+    try:
+        api_client = create_api_client()
+        result = update_document_raw_impl(api_client, item_id, setters)
+
+        return create_simple_response(
+            data=result,
+            summary_text=f"Updated document {item_id} with raw setters",
+            api_endpoint="/doc/update",
+            api_calls_made=1,
+            debug=debug,
+            start_time=start_time,
+        )
+    except Exception as e:
+        logger.exception("Failed to update document %s", item_id)
+        return create_error_response(e, "/doc/update", debug, start_time)
+
+
+@mcp.tool()
+async def add_event(
+    title: str,
+    start: str,
+    length_minutes: int,
+    note: str | None = None,
+    debug: bool = False,
+) -> StandardResponse:
+    """Create a calendar event in Amazing Marvin.
+
+    Args:
+        title: Event title
+        start: Start time as ISO 8601 datetime string
+        length_minutes: Duration in minutes
+        note: Optional event notes
+    """
+    start_time = time.time()
+    try:
+        api_client = create_api_client()
+        result = add_event_impl(api_client, title, start, length_minutes, note)
+
+        return create_simple_response(
+            data=result,
+            summary_text=f"Created event: {title}",
+            api_endpoint="/addEvent",
+            api_calls_made=1,
+            debug=debug,
+            start_time=start_time,
+        )
+    except Exception as e:
+        logger.exception("Failed to create event '%s'", title)
+        return create_error_response(e, "/addEvent", debug, start_time)
+
+
+@mcp.tool()
+async def get_today_time_blocks(
+    date: str | None = None, debug: bool = False
+) -> StandardResponse:
+    """Get time blocks for a date (defaults to today).
+
+    Args:
+        date: Optional date in YYYY-MM-DD format
+    """
+    start_time = time.time()
+    try:
+        api_client = create_api_client()
+        result = get_today_time_blocks_impl(api_client, date)
+
+        return create_simple_response(
+            data=result,
+            summary_text=f"Retrieved {len(result)} time blocks",
+            api_endpoint="/todayTimeBlocks",
+            api_calls_made=1,
+            debug=debug,
+            start_time=start_time,
+        )
+    except Exception as e:
+        logger.exception("Failed to get time blocks")
+        return create_error_response(e, "/todayTimeBlocks", debug, start_time)
+
+
+@mcp.tool()
+async def get_habits(debug: bool = False) -> StandardResponse:
+    """Get all habits from Amazing Marvin."""
+    start_time = time.time()
+    try:
+        api_client = create_api_client()
+        result = get_habits_impl(api_client)
+
+        return create_simple_response(
+            data=result,
+            summary_text=f"Retrieved {len(result)} habits",
+            api_endpoint="/habits",
+            api_calls_made=1,
+            debug=debug,
+            start_time=start_time,
+        )
+    except Exception as e:
+        logger.exception("Failed to get habits")
+        return create_error_response(e, "/habits", debug, start_time)
+
+
+@mcp.tool()
+async def get_habit(habit_id: str, debug: bool = False) -> StandardResponse:
+    """Get a single habit with history from Amazing Marvin.
+
+    Args:
+        habit_id: Habit ID to retrieve
+    """
+    start_time = time.time()
+    try:
+        api_client = create_api_client()
+        result = get_habit_impl(api_client, habit_id)
+
+        return create_simple_response(
+            data=result,
+            summary_text=f"Retrieved habit {habit_id}",
+            api_endpoint="/habit",
+            api_calls_made=1,
+            debug=debug,
+            start_time=start_time,
+        )
+    except Exception as e:
+        logger.exception("Failed to get habit %s", habit_id)
+        return create_error_response(e, "/habit", debug, start_time)
+
+
+@mcp.tool()
+async def record_habit(
+    habit_id: str, value: int | None = None, debug: bool = False
+) -> StandardResponse:
+    """Record a habit occurrence in Amazing Marvin.
+
+    Args:
+        habit_id: Habit ID to record
+        value: Optional value for the habit (e.g., number of glasses of water)
+    """
+    start_time = time.time()
+    try:
+        api_client = create_api_client()
+        result = record_habit_impl(api_client, habit_id, value)
+
+        return create_simple_response(
+            data=result,
+            summary_text=f"Recorded habit {habit_id}",
+            api_endpoint="/updateHabit",
+            api_calls_made=1,
+            debug=debug,
+            start_time=start_time,
+        )
+    except Exception as e:
+        logger.exception("Failed to record habit %s", habit_id)
+        return create_error_response(e, "/updateHabit", debug, start_time)
+
+
+@mcp.tool()
+async def undo_habit(habit_id: str, debug: bool = False) -> StandardResponse:
+    """Undo last habit recording in Amazing Marvin.
+
+    Args:
+        habit_id: Habit ID to undo
+    """
+    start_time = time.time()
+    try:
+        api_client = create_api_client()
+        result = undo_habit_impl(api_client, habit_id)
+
+        return create_simple_response(
+            data=result,
+            summary_text=f"Undid last recording for habit {habit_id}",
+            api_endpoint="/updateHabit",
+            api_calls_made=1,
+            debug=debug,
+            start_time=start_time,
+        )
+    except Exception as e:
+        logger.exception("Failed to undo habit %s", habit_id)
+        return create_error_response(e, "/updateHabit", debug, start_time)
+
+
+@mcp.tool()
+async def set_reminders(
+    reminders: list[dict], debug: bool = False
+) -> StandardResponse:
+    """Set reminders in Amazing Marvin.
+
+    Args:
+        reminders: List of reminder dicts with taskId, reminderTime, and optional note
+    """
+    start_time = time.time()
+    try:
+        api_client = create_api_client()
+        result = set_reminders_impl(api_client, reminders)
+
+        return create_simple_response(
+            data=result,
+            summary_text=f"Set {len(reminders)} reminders",
+            api_endpoint="/reminder/set",
+            api_calls_made=1,
+            debug=debug,
+            start_time=start_time,
+        )
+    except Exception as e:
+        logger.exception("Failed to set reminders")
+        return create_error_response(e, "/reminder/set", debug, start_time)
+
+
+@mcp.tool()
+async def delete_reminders(
+    reminder_ids: list[str], debug: bool = False
+) -> StandardResponse:
+    """Delete specific reminders from Amazing Marvin.
+
+    Args:
+        reminder_ids: List of reminder IDs to delete
+    """
+    start_time = time.time()
+    try:
+        api_client = create_api_client()
+        result = delete_reminders_impl(api_client, reminder_ids)
+
+        return create_simple_response(
+            data=result,
+            summary_text=f"Deleted {len(reminder_ids)} reminders",
+            api_endpoint="/reminder/delete",
+            api_calls_made=1,
+            debug=debug,
+            start_time=start_time,
+        )
+    except Exception as e:
+        logger.exception("Failed to delete reminders")
+        return create_error_response(e, "/reminder/delete", debug, start_time)
+
+
+@mcp.tool()
+async def spend_reward_points(
+    points: int, date: str, debug: bool = False
+) -> StandardResponse:
+    """Spend reward points in Amazing Marvin.
+
+    Args:
+        points: Number of points to spend
+        date: Date in YYYY-MM-DD format
+    """
+    start_time = time.time()
+    try:
+        api_client = create_api_client()
+        result = spend_reward_points_impl(api_client, points, date)
+
+        return create_simple_response(
+            data=result,
+            summary_text=f"Spent {points} reward points",
+            api_endpoint="/spendRewardPoints",
+            api_calls_made=1,
+            debug=debug,
+            start_time=start_time,
+        )
+    except Exception as e:
+        logger.exception("Failed to spend reward points")
+        return create_error_response(e, "/spendRewardPoints", debug, start_time)
+
+
+@mcp.tool()
+async def unclaim_reward_points(
+    item_id: str, date: str, debug: bool = False
+) -> StandardResponse:
+    """Unclaim reward points for an item in Amazing Marvin.
+
+    Args:
+        item_id: Item ID to unclaim points for
+        date: Date in YYYY-MM-DD format
+    """
+    start_time = time.time()
+    try:
+        api_client = create_api_client()
+        result = unclaim_reward_points_impl(api_client, item_id, date)
+
+        return create_simple_response(
+            data=result,
+            summary_text=f"Unclaimed reward points for item {item_id}",
+            api_endpoint="/unclaimRewardPoints",
+            api_calls_made=1,
+            debug=debug,
+            start_time=start_time,
+        )
+    except Exception as e:
+        logger.exception("Failed to unclaim reward points")
+        return create_error_response(e, "/unclaimRewardPoints", debug, start_time)
 
 
 def start():

--- a/src/amazing_marvin_mcp/models.py
+++ b/src/amazing_marvin_mcp/models.py
@@ -1,0 +1,49 @@
+"""Pydantic request models for Amazing Marvin API operations."""
+
+from pydantic import BaseModel, Field
+
+
+class TaskUpdateRequest(BaseModel):
+    """Friendly task update - converted to setters internally."""
+
+    item_id: str
+    title: str | None = None
+    due_date: str | None = Field(default=None, description="YYYY-MM-DD")
+    scheduled_date: str | None = Field(
+        default=None, description="YYYY-MM-DD (maps to 'day' in Marvin)"
+    )
+    note: str | None = None
+    label_ids: list[str] | None = None
+    priority: str | None = None
+    parent_id: str | None = None
+    is_starred: bool | None = None
+    is_frogged: bool | None = None
+    time_estimate: int | None = Field(
+        default=None, description="Time estimate in minutes"
+    )
+    backburner: bool | None = None
+
+
+class EventCreateRequest(BaseModel):
+    """Request to create a calendar event."""
+
+    title: str
+    start: str = Field(description="ISO 8601 datetime string")
+    length_minutes: int = Field(description="Duration in minutes")
+    note: str | None = None
+
+
+class HabitUpdateRequest(BaseModel):
+    """Request to record or undo a habit."""
+
+    habit_id: str
+    action: str = Field(description="'record' or 'undo'")
+    value: int | None = Field(default=None, description="Optional value for the habit")
+
+
+class ReminderSetRequest(BaseModel):
+    """A single reminder to set."""
+
+    task_id: str
+    reminder_time: str = Field(description="ISO 8601 datetime string")
+    note: str | None = None

--- a/src/amazing_marvin_mcp/reminders.py
+++ b/src/amazing_marvin_mcp/reminders.py
@@ -1,0 +1,19 @@
+"""Reminder set/delete operations."""
+
+from typing import Any
+
+from .api import MarvinAPIClient
+
+
+def set_reminders(
+    api_client: MarvinAPIClient, reminders: list[dict[str, Any]]
+) -> dict[str, Any]:
+    """Set reminders."""
+    return api_client.set_reminders(reminders)
+
+
+def delete_reminders(
+    api_client: MarvinAPIClient, reminder_ids: list[str]
+) -> dict[str, Any]:
+    """Delete specific reminders by ID."""
+    return api_client.delete_reminders(reminder_ids)

--- a/src/amazing_marvin_mcp/rewards.py
+++ b/src/amazing_marvin_mcp/rewards.py
@@ -1,0 +1,19 @@
+"""Extended reward point operations."""
+
+from typing import Any
+
+from .api import MarvinAPIClient
+
+
+def spend_reward_points(
+    api_client: MarvinAPIClient, points: int, date: str
+) -> dict[str, Any]:
+    """Spend reward points."""
+    return api_client.spend_reward_points(points, date)
+
+
+def unclaim_reward_points(
+    api_client: MarvinAPIClient, item_id: str, date: str
+) -> dict[str, Any]:
+    """Unclaim reward points for an item."""
+    return api_client.unclaim_reward_points(item_id, date)

--- a/src/amazing_marvin_mcp/setters_builder.py
+++ b/src/amazing_marvin_mcp/setters_builder.py
@@ -1,0 +1,49 @@
+"""Convert TaskUpdateRequest into Marvin's setters format for /doc/update."""
+
+import time
+
+from .models import TaskUpdateRequest
+
+# Map snake_case model fields to Marvin camelCase keys
+_FIELD_MAP: dict[str, str] = {
+    "title": "title",
+    "due_date": "dueDate",
+    "scheduled_date": "day",
+    "note": "note",
+    "label_ids": "labelIds",
+    "priority": "priority",
+    "parent_id": "parentId",
+    "is_starred": "isStarred",
+    "is_frogged": "isFrogged",
+    "time_estimate": "timeEstimate",
+    "backburner": "backburner",
+}
+
+
+def build_setters(update: TaskUpdateRequest) -> dict:
+    """Convert a TaskUpdateRequest into Marvin's $set + fieldUpdates format.
+
+    Only includes fields that are not None. Adds updatedAt and
+    fieldUpdates.<key> timestamps automatically.
+    """
+    now_ms = int(time.time() * 1000)
+    set_values: dict = {}
+    field_updates: dict = {}
+
+    for model_field, marvin_key in _FIELD_MAP.items():
+        value = getattr(update, model_field)
+        if value is None:
+            continue
+        # Convert time_estimate from minutes to milliseconds for Marvin
+        if model_field == "time_estimate":
+            value = value * 60 * 1000
+        set_values[marvin_key] = value
+        field_updates[marvin_key] = now_ms
+
+    set_values["updatedAt"] = now_ms
+
+    result: dict = {"$set": set_values}
+    if field_updates:
+        result["$set"]["fieldUpdates"] = field_updates
+
+    return result

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8,7 +8,13 @@ import requests
 from amazing_marvin_mcp.analytics import get_productivity_summary
 from amazing_marvin_mcp.api import MarvinAPIClient, create_api_client
 from amazing_marvin_mcp.config import get_settings
+from amazing_marvin_mcp.documents import get_document, update_task_friendly
+from amazing_marvin_mcp.events import add_event, get_today_time_blocks
+from amazing_marvin_mcp.habits import get_habit, get_habits, record_habit, undo_habit
+from amazing_marvin_mcp.models import TaskUpdateRequest
 from amazing_marvin_mcp.projects import create_project_with_tasks
+from amazing_marvin_mcp.reminders import delete_reminders, set_reminders
+from amazing_marvin_mcp.rewards import spend_reward_points, unclaim_reward_points
 from amazing_marvin_mcp.tasks import (
     batch_create_tasks,
     get_daily_focus,
@@ -292,6 +298,148 @@ class TestProjectPlanningEnhancements:
         assert "success_count" in result
         assert result["success_count"] >= 0
         assert result["total_requested"] == TASK_COUNT
+
+
+class TestFullAccessOperations:
+    """Test operations requiring full access token."""
+
+    @pytest.fixture
+    def full_access_client(self):
+        """Create API client with full access token."""
+        try:
+            settings = get_settings()
+            if not settings.amazing_marvin_full_access_token:
+                pytest.skip("No full access token available")
+            return create_api_client()
+        except Exception:
+            pytest.skip("Configuration error - cannot create full access client")
+
+    def test_get_document(self, full_access_client, test_task_data):
+        """Test reading a document by ID."""
+        # Create a task first to get a valid ID
+        created = full_access_client.create_task(test_task_data)
+        task_id = created["_id"]
+
+        doc = get_document(full_access_client, task_id)
+        assert doc is not None
+        assert doc.get("title") == test_task_data["title"]
+
+    def test_update_task(self, full_access_client, test_task_data):
+        """Test updating a task via friendly model."""
+        created = full_access_client.create_task(test_task_data)
+        task_id = created["_id"]
+
+        update = TaskUpdateRequest(item_id=task_id, title="Updated by pytest")
+        result = update_task_friendly(full_access_client, update)
+        assert result is not None
+
+
+class TestEventOperations:
+    """Test event and time block operations."""
+
+    def test_add_event(self, api_client):
+        """Test creating a calendar event."""
+        try:
+            result = add_event(
+                api_client,
+                title="Pytest Event",
+                start="2025-12-31T10:00:00Z",
+                length_minutes=30,
+                note="Test event",
+            )
+            assert result is not None
+        except Exception as e:
+            pytest.skip(f"Event creation not available: {e}")
+
+    def test_get_today_time_blocks(self, api_client):
+        """Test getting time blocks."""
+        try:
+            result = get_today_time_blocks(api_client)
+            assert isinstance(result, list)
+        except Exception as e:
+            pytest.skip(f"Time blocks not available: {e}")
+
+
+class TestHabitOperations:
+    """Test habit operations."""
+
+    def test_get_habits(self, api_client):
+        """Test listing all habits."""
+        try:
+            result = get_habits(api_client)
+            assert isinstance(result, list)
+        except Exception as e:
+            pytest.skip(f"Habits not available: {e}")
+
+    def test_get_habit(self, api_client):
+        """Test getting a single habit."""
+        try:
+            habits = get_habits(api_client)
+            if not habits:
+                pytest.skip("No habits exist to test")
+            habit_id = habits[0].get("_id")
+            result = get_habit(api_client, habit_id)
+            assert result is not None
+        except Exception as e:
+            pytest.skip(f"Habit retrieval not available: {e}")
+
+    def test_record_and_undo_habit(self, api_client):
+        """Test recording and undoing a habit."""
+        try:
+            habits = get_habits(api_client)
+            if not habits:
+                pytest.skip("No habits exist to test")
+            habit_id = habits[0].get("_id")
+
+            record_result = record_habit(api_client, habit_id)
+            assert record_result is not None
+
+            undo_result = undo_habit(api_client, habit_id)
+            assert undo_result is not None
+        except Exception as e:
+            pytest.skip(f"Habit record/undo not available: {e}")
+
+
+class TestReminderOperations:
+    """Test reminder operations."""
+
+    def test_set_and_delete_reminders(self, api_client):
+        """Test setting and deleting reminders."""
+        try:
+            reminders = [
+                {
+                    "taskId": "test_task",
+                    "reminderTime": "2025-12-31T09:00:00Z",
+                }
+            ]
+            result = set_reminders(api_client, reminders)
+            assert result is not None
+        except Exception as e:
+            pytest.skip(f"Reminder operations not available: {e}")
+
+
+class TestRewardExtendedOperations:
+    """Test extended reward operations."""
+
+    def test_spend_reward_points(self, api_client):
+        """Test spending reward points."""
+        today = datetime.now().strftime("%Y-%m-%d")
+        try:
+            result = spend_reward_points(api_client, 1, today)
+            assert result is not None
+        except Exception as e:
+            pytest.skip(f"Spend reward points not available: {e}")
+
+    def test_unclaim_reward_points(self, api_client, test_task_data):
+        """Test unclaiming reward points."""
+        today = datetime.now().strftime("%Y-%m-%d")
+        try:
+            created = api_client.create_task(test_task_data)
+            task_id = created["_id"]
+            result = unclaim_reward_points(api_client, task_id, today)
+            assert result is not None
+        except Exception as e:
+            pytest.skip(f"Unclaim reward points not available: {e}")
 
 
 if __name__ == "__main__":

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,106 @@
+"""Tests for Pydantic request models."""
+
+import pytest
+from pydantic import ValidationError
+
+from amazing_marvin_mcp.models import (
+    EventCreateRequest,
+    HabitUpdateRequest,
+    ReminderSetRequest,
+    TaskUpdateRequest,
+)
+
+
+class TestTaskUpdateRequest:
+    """Test TaskUpdateRequest model validation."""
+
+    def test_minimal_update(self):
+        update = TaskUpdateRequest(item_id="abc123")
+        assert update.item_id == "abc123"
+        assert update.title is None
+        assert update.due_date is None
+
+    def test_full_update(self):
+        update = TaskUpdateRequest(
+            item_id="abc123",
+            title="New Title",
+            due_date="2025-12-31",
+            scheduled_date="2025-12-30",
+            note="Some notes",
+            label_ids=["lbl1", "lbl2"],
+            priority="high",
+            parent_id="proj1",
+            is_starred=True,
+            is_frogged=False,
+            time_estimate=30,
+            backburner=False,
+        )
+        assert update.title == "New Title"
+        assert update.label_ids == ["lbl1", "lbl2"]
+        assert update.time_estimate == 30
+
+    def test_missing_item_id_raises(self):
+        with pytest.raises(ValidationError):
+            TaskUpdateRequest()  # type: ignore[call-arg]
+
+
+class TestEventCreateRequest:
+    """Test EventCreateRequest model validation."""
+
+    def test_valid_event(self):
+        event = EventCreateRequest(
+            title="Meeting",
+            start="2025-12-31T10:00:00Z",
+            length_minutes=60,
+            note="Team sync",
+        )
+        assert event.title == "Meeting"
+        assert event.length_minutes == 60
+
+    def test_minimal_event(self):
+        event = EventCreateRequest(
+            title="Meeting",
+            start="2025-12-31T10:00:00Z",
+            length_minutes=30,
+        )
+        assert event.note is None
+
+    def test_missing_required_fields(self):
+        with pytest.raises(ValidationError):
+            EventCreateRequest(title="Meeting")  # type: ignore[call-arg]
+
+
+class TestHabitUpdateRequest:
+    """Test HabitUpdateRequest model validation."""
+
+    def test_record_habit(self):
+        habit = HabitUpdateRequest(habit_id="hab1", action="record")
+        assert habit.action == "record"
+        assert habit.value is None
+
+    def test_record_with_value(self):
+        habit = HabitUpdateRequest(habit_id="hab1", action="record", value=3)
+        assert habit.value == 3
+
+    def test_undo_habit(self):
+        habit = HabitUpdateRequest(habit_id="hab1", action="undo")
+        assert habit.action == "undo"
+
+
+class TestReminderSetRequest:
+    """Test ReminderSetRequest model validation."""
+
+    def test_valid_reminder(self):
+        reminder = ReminderSetRequest(
+            task_id="task1",
+            reminder_time="2025-12-31T09:00:00Z",
+            note="Don't forget!",
+        )
+        assert reminder.task_id == "task1"
+
+    def test_minimal_reminder(self):
+        reminder = ReminderSetRequest(
+            task_id="task1",
+            reminder_time="2025-12-31T09:00:00Z",
+        )
+        assert reminder.note is None

--- a/tests/test_setters_builder.py
+++ b/tests/test_setters_builder.py
@@ -1,0 +1,108 @@
+"""Tests for setters builder conversion."""
+
+from unittest.mock import patch
+
+from amazing_marvin_mcp.models import TaskUpdateRequest
+from amazing_marvin_mcp.setters_builder import build_setters
+
+FROZEN_TIME_MS = 1700000000000
+
+
+class TestBuildSetters:
+    """Test conversion from TaskUpdateRequest to Marvin setters format."""
+
+    @patch("amazing_marvin_mcp.setters_builder.time")
+    def test_title_only(self, mock_time):
+        mock_time.time.return_value = FROZEN_TIME_MS / 1000
+        update = TaskUpdateRequest(item_id="task1", title="New Title")
+        result = build_setters(update)
+
+        assert "$set" in result
+        assert result["$set"]["title"] == "New Title"
+        assert result["$set"]["updatedAt"] == FROZEN_TIME_MS
+        assert result["$set"]["fieldUpdates"]["title"] == FROZEN_TIME_MS
+
+    @patch("amazing_marvin_mcp.setters_builder.time")
+    def test_due_date_maps_correctly(self, mock_time):
+        mock_time.time.return_value = FROZEN_TIME_MS / 1000
+        update = TaskUpdateRequest(item_id="task1", due_date="2025-12-31")
+        result = build_setters(update)
+
+        assert result["$set"]["dueDate"] == "2025-12-31"
+
+    @patch("amazing_marvin_mcp.setters_builder.time")
+    def test_scheduled_date_maps_to_day(self, mock_time):
+        mock_time.time.return_value = FROZEN_TIME_MS / 1000
+        update = TaskUpdateRequest(item_id="task1", scheduled_date="2025-12-30")
+        result = build_setters(update)
+
+        assert result["$set"]["day"] == "2025-12-30"
+
+    @patch("amazing_marvin_mcp.setters_builder.time")
+    def test_time_estimate_converts_to_ms(self, mock_time):
+        mock_time.time.return_value = FROZEN_TIME_MS / 1000
+        update = TaskUpdateRequest(item_id="task1", time_estimate=30)
+        result = build_setters(update)
+
+        # 30 minutes * 60 seconds * 1000 ms
+        assert result["$set"]["timeEstimate"] == 30 * 60 * 1000
+
+    @patch("amazing_marvin_mcp.setters_builder.time")
+    def test_boolean_fields(self, mock_time):
+        mock_time.time.return_value = FROZEN_TIME_MS / 1000
+        update = TaskUpdateRequest(
+            item_id="task1", is_starred=True, is_frogged=False, backburner=True
+        )
+        result = build_setters(update)
+
+        assert result["$set"]["isStarred"] is True
+        assert result["$set"]["isFrogged"] is False
+        assert result["$set"]["backburner"] is True
+
+    @patch("amazing_marvin_mcp.setters_builder.time")
+    def test_none_fields_excluded(self, mock_time):
+        mock_time.time.return_value = FROZEN_TIME_MS / 1000
+        update = TaskUpdateRequest(item_id="task1", title="Only Title")
+        result = build_setters(update)
+
+        set_values = result["$set"]
+        assert "dueDate" not in set_values
+        assert "day" not in set_values
+        assert "note" not in set_values
+        assert "labelIds" not in set_values
+
+    @patch("amazing_marvin_mcp.setters_builder.time")
+    def test_label_ids(self, mock_time):
+        mock_time.time.return_value = FROZEN_TIME_MS / 1000
+        update = TaskUpdateRequest(item_id="task1", label_ids=["lbl1", "lbl2"])
+        result = build_setters(update)
+
+        assert result["$set"]["labelIds"] == ["lbl1", "lbl2"]
+
+    @patch("amazing_marvin_mcp.setters_builder.time")
+    def test_multiple_fields(self, mock_time):
+        mock_time.time.return_value = FROZEN_TIME_MS / 1000
+        update = TaskUpdateRequest(
+            item_id="task1",
+            title="Updated",
+            due_date="2025-12-31",
+            note="Notes here",
+            priority="high",
+        )
+        result = build_setters(update)
+
+        set_values = result["$set"]
+        assert set_values["title"] == "Updated"
+        assert set_values["dueDate"] == "2025-12-31"
+        assert set_values["note"] == "Notes here"
+        assert set_values["priority"] == "high"
+        assert len(result["$set"]["fieldUpdates"]) == 4
+
+    @patch("amazing_marvin_mcp.setters_builder.time")
+    def test_no_updates_still_has_updated_at(self, mock_time):
+        mock_time.time.return_value = FROZEN_TIME_MS / 1000
+        update = TaskUpdateRequest(item_id="task1")
+        result = build_setters(update)
+
+        assert result["$set"]["updatedAt"] == FROZEN_TIME_MS
+        assert "fieldUpdates" not in result["$set"]


### PR DESCRIPTION

Add 14 new MCP tools covering the remaining Marvin API surface:
- Document read/update via full access token (get_document, update_task, update_document_raw)
- Calendar events and time blocks (add_event, get_today_time_blocks)
- Habits (get_habits, get_habit, record_habit, undo_habit)
- Reminders (set_reminders, delete_reminders)
- Extended rewards (spend_reward_points, unclaim_reward_points)

Introduces dual-header support in the API client (X-API-Token / X-Full-Access-Token), Pydantic request models for type safety, and a setters builder that converts friendly field updates into Marvin's $set format. Destructive operations (delete task, delete all reminders, reset rewards) are excluded by design.